### PR TITLE
Use AX1H05.ITM as base item for Rythe's Last Arrow

### DIFF
--- a/JA#BGT_AdvPack/RythesLastArrow/setup-RythesLastArrow.tpa
+++ b/JA#BGT_AdvPack/RythesLastArrow/setup-RythesLastArrow.tpa
@@ -2,11 +2,12 @@
 //RESTORED: Item-descriptions - Rythe's Last Arrow
 ///////////////////////////////////////////////////
 
-COPY_EXISTING ~AX1H06.ITM~ ~override/JA#AX1H6.ITM~
+COPY_EXISTING ~AX1H05.ITM~ ~override/JA#AX1H5.ITM~
+	SAY NAME2 @2023
 	SAY DESC @2000
 
 COPY_EXISTING ~PRAT.CRE~ ~override~
-	REPLACE_CRE_ITEM ~JA#AX1H6~ #0 #0 #0 ~NONE~ ~WEAPON1~ EQUIP
+	REPLACE_CRE_ITEM ~JA#AX1H5~ #0 #0 #0 ~NONE~ ~WEAPON1~ EQUIP
 
 COPY ~JA#BGT_AdvPack/RythesLastArrow/JA#BELT1.BAM~ ~override~
 COPY ~JA#BGT_AdvPack/RythesLastArrow/JA#BELT1.ITM~ ~override~

--- a/JA#BGT_AdvPack/languages/english/setup.tra
+++ b/JA#BGT_AdvPack/languages/english/setup.tra
@@ -355,7 +355,7 @@ Thieves, druids, sorcerer, clerics, mages, monks~
 
 
 
-
+@2023 = ~Rhyte's Last Arrow~
 @2024 = ~Durlag's Pride~
 @2025 = ~The Edge of the World~
 @2026 = ~The whistling sword~

--- a/JA#BGT_AdvPack/languages/german/Setup.tra
+++ b/JA#BGT_AdvPack/languages/german/Setup.tra
@@ -355,6 +355,7 @@ Kann nicht verwendet werden von:
 - Klerikern
 - Magiern
 - Mönchen~
+@2023	= ~Rhytes letzter Pfeil~
 @2024	= ~Durlags Stolz~
 @2025	= ~Der Rand der Welt~
 @2026	= ~Das pfeifende Schwert~


### PR DESCRIPTION
In BGT AX1H06.ITM is kind of bugged: It creates a duplicate on every ranged hit!
So we are using AX1H05.ITM as base item for Rythe's Last Arrow. It also fits the damage description in setup.tra

In BG1:SOD different versions Rythe's Last Arrow and The Protector of the Unworthy are also obtainable.
Maybe introduce a Disclaimer to avoid confusion for EE players?